### PR TITLE
Reset reorder

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -513,7 +513,14 @@ export default Component => {
         if (JSON.stringify(originalOrder) !== JSON.stringify(newOrder)) {
           if (onDraggedColumnChange) onDraggedColumnChange(cols)
         }
+
+        // if a new array of columns, reset the reorder since it's not relevant any more
+        if (this.previousOrigColumns && this.previousOrigColumns !== origColumns) {
+          this.reorder = []
+        }
       }
+
+      this.previousOrigColumns = origColumns
 
       // render
       return (

--- a/src/index.js
+++ b/src/index.js
@@ -509,14 +509,13 @@ export default Component => {
           return col.accessor
         })
 
-        // if order is not equal, then call onDraggedColumnChange prop
-        if (JSON.stringify(originalOrder) !== JSON.stringify(newOrder)) {
-          if (onDraggedColumnChange) onDraggedColumnChange(cols)
-        }
-
         // if a new array of columns, reset the reorder since it's not relevant any more
         if (this.previousOrigColumns && this.previousOrigColumns !== origColumns) {
           this.reorder = []
+        }
+        // if order is not equal, then call onDraggedColumnChange prop
+        else if (JSON.stringify(originalOrder) !== JSON.stringify(newOrder)) {
+          if (onDraggedColumnChange) onDraggedColumnChange(cols)
         }
       }
 


### PR DESCRIPTION
This is a fork of the package we use for the draggable columns. 
I had to adapt it to our needs since we have the ability to change columns after the table is rendered, and it wasn't support by default